### PR TITLE
g700s profiles support

### DIFF
--- a/doc/profile.md
+++ b/doc/profile.md
@@ -12,7 +12,7 @@ There are different structures for profiles:
    - G500 (c068)
    - G500s (c24e)
  - [Profile for G700s](profile/g700s.md) supported by:
-   - G700s
+   - G700s (c70c)
 
 Button binding
 --------------
@@ -21,7 +21,7 @@ Supported devices:
  - G9 (c048)
  - G500 (c068)
  - G500s (c24e)
- - G700s
+ - G700s (c70c)
 
 Each button is 3 byte long.  The first byte indicate the binding type, the next two bytes depends on the type:
 
@@ -57,13 +57,17 @@ The special functions are:
  - 0x0002: pan right (horizontal wheel +1) (G500(s), G700s).
  - 0x0003: battery level (G700s)
  - 0x0004: next DPI mode (G500(s), G700s).
+ - 0x0005: cycle DPI mode up (G700s).
  - 0x0008: previous DPI mode (G500(s), G700s).
- - 0x0009: cycle DPI mode (G700s)
- - 0x0010: next profile (G500)
+ - 0x0009: cycle DPI mode down (G700s)
+ - 0x0010: next profile (G500, G700s)
  - 0x0011: cycle profile (G700s)
- - 0x0020: previous profile (G500)
-
-
+ - 0x0020: previous profile (G500, G700s)
+ - 0x0040: switch to profile 1 (G700s)
+ - 0x0080: battery level (G700s)
+ - 0x0100: battery level (G700s)
+ - 0x0105: same as 0x0005 used in default profile on page 25 (G700s)
+ 
 ### 0x84 – Consumer control
 
 The next bytes are a 16 bits big-endian integer containing the HID usage from the consumer control page.

--- a/doc/profile/g700s.md
+++ b/doc/profile/g700s.md
@@ -15,12 +15,12 @@ The profile is 74 bytes long.
 | 21    |              | Angle?                         | 0x80                     |
 | 22    |              | Angle Snap?                    | 0x01 (off?)              |
 | 23    |              | Acceleration?                  | 0x10                     |
-| 24    | byte         | USB refresh rate?              | 0x02 or 0x01 or 0x08     |
+| 24    | byte         | USB refresh rate               | 0x02 or 0x01 or 0x08     |
 | 25    | byte         | ?                              | 0x00 or 0x01             |
 | 26    | byte         | ?                              | 0x2c or 0x0a             |
 | 27    | byte         | ?                              | 0x00 or 0x02 or 0x04     |
 | 28    | byte         | ?                              | 0x58 or 0xb0 or 0x3c     |
-| 29    | byte         | ?                              | 0x64 or 0xc8 or 0x32     |
+| 29    | byte         | Energy saving mode             | 0x64 or 0xc8 or 0x32     |
 | 30    | byte         | ?                              | 0xff or 0x1f             |
 | 31–34 |              | ?                              | `bc 00 09 31`            |
 | 35–73 | struct array | 13 3-byte-long button bindings |                          |
@@ -55,3 +55,9 @@ All bytes are null when the mode is disabled.
 | 11     | Wheel tilt left  |
 | 12     | Wheel tilt right |
 
+### Energy saving mode
+
+| Value | Mode          |
+| 0xc8  | Max gaming    |
+| 0x64  | Normal gaming |
+| 0x32  | Energy saving |

--- a/doc/resolution.md
+++ b/doc/resolution.md
@@ -49,7 +49,7 @@ The resolution is two 16 bits integer (X and Y axes).
 Highest resolution is 0x00F3 (5700 dpi).
 
 
-### G500s
+### G500s, G700s
 
 The resolution is two 16 bits integer (X and Y axes).
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,8 +16,9 @@ EXE_SRC=g500-dump-page.c \
 	g500-edit-profile.c \
 	check-hidraw-logitech-reports.c \
 	logitech-raw-command.c \
+	g700s-parse-profile.c \
 	send-raw-request.c
-LIB_SRC=logitech.c g500.c
+LIB_SRC=logitech.c g500.c g700s.c
 
 SRC=$(EXE_SRC) $(LIB_SRC)
 EXE_OBJ=$(EXE_SRC:.c=.o)

--- a/src/g500-parse-macro.c
+++ b/src/g500-parse-macro.c
@@ -42,9 +42,10 @@ int main (int argc, char *argv[]) {
 	int offset = 0;
 	if (argc > 1)
 		offset = strtol (argv[1], NULL, 0);
-	
+
 	int i = 2*offset;
 	int end = 0;
+    int j;
 	while (!end) {
 		struct g500_macro_item_t *macro_item = (struct g500_macro_item_t *)&buffer[i];
 		if (i % 2 == 0)
@@ -69,16 +70,92 @@ int main (int argc, char *argv[]) {
 			end = 1;
 			break;
 		case G500_MACRO_KEY_PRESS:
-			printf ("KEY PRESS 0x%02hhX\n", macro_item->value.key_usage);
+			/*if pressed key is letter print it instead of hid code */
+			if ((macro_item->value.key_usage > 0x03) && (macro_item->value.key_usage < 0x1E))
+				printf ("KEY PRESS %c\n", macro_item->value.key_usage - 0x04 + 0x41);
+			else
+				printf ("KEY PRESS 0x%02hhX\n", macro_item->value.key_usage);
 			break;
 		case G500_MACRO_KEY_RELEASE:
-			printf ("KEY RELEASE 0x%02hhX\n", macro_item->value.key_usage);
+			/*if released key is letter print it instead of hid code */
+			if ((macro_item->value.key_usage > 0x03) && (macro_item->value.key_usage < 0x1E))
+				printf ("KEY RELEASE %c\n", macro_item->value.key_usage - 0x04 + 0x41);
+			else
+				printf ("KEY RELEASE 0x%02hhX\n", macro_item->value.key_usage);
 			break;
 		case G500_MACRO_MODIFIER_PRESS:
-			printf ("MODIFIER PRESS 0x%02hhX\n", macro_item->value.modifier_bits);
+			printf("MODIFIER PRESS ");
+            for(j = 0; j < 8; ++j){
+                if (macro_item->value.modifier_bits & (1<<j)){
+                    switch(j + 0xE0 - 1){
+                        case 0xE0:
+                            printf("LeftControl ");
+                            break;
+                        case 0xE1:
+                            printf("LeftShift ");
+                            break;
+                        case 0xE2:
+                            printf("LeftAlt ");
+                            break;
+                        case 0xE3:
+                            printf("Left GUI ");
+                            break;
+                        case 0xE4:
+                            printf("RightControl ");
+                            break;
+                        case 0xE5:
+                            printf("RightShift ");
+                            break;
+                        case 0xE6:
+                            printf("RightAlt ");
+                            break;
+                        case 0xE7:
+                            printf("Right GUI ");
+                            break;
+                        default:
+                            printf ("0x%02hhX\n", macro_item->value.modifier_bits);
+
+                    }
+                }
+            }
+            printf("\n");
 			break;
 		case G500_MACRO_MODIFIER_RELEASE:
-			printf ("MODIFIER RELEASE 0x%02hhX\n", macro_item->value.modifier_bits);
+			printf("MODIFIER RELEASE ");
+            for(j = 0; j < 8; ++j){
+                if (macro_item->value.modifier_bits & (1<<j)){
+                    switch(j + 0xE0 - 1){
+                        case 0xE0:
+                            printf("LeftControl ");
+                            break;
+                        case 0xE1:
+                            printf("LeftShift ");
+                            break;
+                        case 0xE2:
+                            printf("LeftAlt ");
+                            break;
+                        case 0xE3:
+                            printf("Left GUI ");
+                            break;
+                        case 0xE4:
+                            printf("RightControl ");
+                            break;
+                        case 0xE5:
+                            printf("RightShift ");
+                            break;
+                        case 0xE6:
+                            printf("RightAlt ");
+                            break;
+                        case 0xE7:
+                            printf("Right GUI ");
+                            break;
+                        default:
+                            printf ("0x%02hhX\n", macro_item->value.modifier_bits);
+
+                    }
+                }
+            }
+            printf("\n");
 			break;
 		case G500_MACRO_WHEEL:
 			printf ("WHEEL %hhd\n", macro_item->value.wheel);

--- a/src/g700s-parse-profile.c
+++ b/src/g700s-parse-profile.c
@@ -1,0 +1,182 @@
+/*
+* Copyright 2015 Clément Vuchener
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <endian.h>
+
+#include "g700s.h"
+
+const char *onoff_to_string (int value);
+
+int main (int argc, char *argv[]) {
+	int i, j;
+	uint8_t buffer[G700S_PAGE_SIZE];
+
+	int ret, r = 0;
+	do {
+		ret = read (0, &buffer[r], G700S_PAGE_SIZE-r);
+		if (ret == -1) {
+			perror ("read");
+			return EXIT_FAILURE;
+		}
+		r += ret;
+	} while (r != G700S_PAGE_SIZE && ret != 0);
+
+	struct g700s_profile_t *profile = (struct g700s_profile_t *)buffer;
+
+	printf ("dpi modes:\n");
+	for (i = 0; i < 5; ++i) {
+		printf (" - Mode %d: %ddpi %ddpi",
+			i,
+			g700s_unpack_resolution (profile->dpi_mode[i].resolution[0]),
+			g700s_unpack_resolution (profile->dpi_mode[i].resolution[1])
+			);
+		for (j = 0; j < 4; ++j) {
+			int led = (le16toh (profile->dpi_mode[i].leds) & (0x0F << 4*j)) >> 4*j;
+			printf (" %s", onoff_to_string (led));
+		}
+		printf ("\n");
+	}
+
+	printf ("angle correction: %s\n", onoff_to_string (profile->angle));
+	printf ("default dpi mode: %d\n", profile->default_mode);
+	printf ("refresh rate: %dHz\n", g700s_unpack_refresh_rate (profile->refresh_rate));
+	printf ("Unknown bytes:\n25: %x\n26: %x\n27: %x\n28: %x\n29: %x\n30: %x\n",
+			profile->unk[0],
+			profile->unk[1],
+			profile->unk[2],
+			profile->unk[3],
+			profile->unk[4],
+			profile->unk[5]);
+
+
+	printf ("bindings:\n");
+	for (i = 0; i < 13; ++i) {
+		//printf (" - button %d -> ", i);
+        printf ("- %-16s -> ",g700s_button_name(i));
+
+		if (profile->binding[i].type <= G700S_BINDING_MACRO_MAX) {
+			printf ("macro (0x%02hhX:0x%02hhX)",
+				profile->binding[i].type,
+				profile->binding[i].value.macro.offset);
+		}
+		else switch (profile->binding[i].type) {
+		case G700S_BINDING_MOUSE_BUTTON:
+			printf ("mouse button %d",
+				g700s_get_button_num (le16toh (profile->binding[i].value.button)));
+			break;
+		case G700S_BINDING_KEY:
+			printf ("key ");
+			for (j = 0; j < 8; ++j) {
+				if (profile->binding[i].value.key.modifier & (1<<j))
+				    //	printf ("0x%X + ", 0xE0+j); // 0xE0 is the minimum usage for modifier keys
+                    switch(0xE0 + j){
+                        case 0xE0:
+                            printf("LeftControl ");
+                            break;
+               	        case 0xE1:
+                            printf("LeftShift ");
+                            break;
+                        case 0xE2:
+                            printf("LeftAlt ");
+                            break;
+                        case 0xE3:
+                            printf("Left GUI ");
+                            break;
+                        case 0xE4:
+                            printf("RightControl ");
+                            break;
+                        case 0xE5:
+                            printf("RightShift ");
+                            break;
+                        case 0xE6:
+                            printf("RightAlt ");
+                            break;
+                        case 0xE7:
+                            printf("Right GUI ");
+                            break;
+                    }
+			}
+			if ((profile->binding[i].value.key.usage > 0x03) && (profile->binding[i].value.key.usage < 0x1E))
+				printf ("%c", profile->binding[i].value.key.usage - 0x04 + 0x41);
+			else
+				printf ("0x%02hhX", profile->binding[i].value.key.usage);
+			break;
+		case G700S_BINDING_SPECIAL_BUTTON:
+			printf ("special ");
+			switch (le16toh(profile->binding[i].value.button)) {
+			case G700S_SPECIAL_BUTTON_PAN_LEFT:
+				printf ("pan left");
+				break;
+			case G700S_SPECIAL_BUTTON_PAN_RIGHT:
+				printf ("pan right");
+				break;
+			case G700S_SPECIAL_BUTTON_DPI_PLUS:
+				printf ("dpi +");
+				break;
+			case G700S_SPECIAL_BUTTON_DPI_MINUS:
+				printf ("dpi -");
+				break;
+			case G700S_SPECIAL_BUTTON_BATTERY:
+				printf ("battery level");
+				break;
+			case G700S_SPECIAL_BUTTON_PROFILE_CYC:
+				printf ("cycle profile");
+				break;
+			case G700S_SPECIAL_BUTTON_DPI_CYC_DOWN:
+				printf ("cycle dpi down");
+				break;
+			case G700S_SPECIAL_BUTTON_DPI_CYC_UP:
+				printf ("cycle dpi up");
+				break;
+			default:
+				printf ("unknown %x", le16toh(profile->binding[i].value.button));
+			}
+			break;
+		case G700S_BINDING_CONSUMER_CONTROL:
+			printf ("consumer control 0x%X", be16toh (profile->binding[i].value.cc_usage));
+			break;
+		case G700S_BINDING_UNSET:
+			printf ("unset");
+			break;
+		default:
+			printf ("unknown (0x%02hhX) %02hhX %02hhX",
+				profile->binding[i].type,
+				profile->binding[i].value.bytes[0],
+				profile->binding[i].value.bytes[1]);
+		}
+		printf ("\n");
+	}
+	return EXIT_SUCCESS;
+}
+
+const char *onoff_to_string (int value) {
+	static char error_str[32];
+	switch (value) {
+	case 1:
+		return "off";
+	case 2:
+		return "on";
+	default:
+		snprintf (error_str, sizeof (error_str), "invalid (%d)", value);
+		return error_str;
+	}
+}

--- a/src/g700s.c
+++ b/src/g700s.c
@@ -1,0 +1,306 @@
+/*
+* Copyright 2015 Clément Vuchener
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "g700s.h"
+
+#include <string.h>
+#include <endian.h>
+#include "logitech.h"
+
+#ifdef DEBUG
+#include <stdio.h>
+#endif
+
+int g700s_disable_profile (int fd) {
+	struct g700s_profile_params_t params;
+	memset (&params, 0, sizeof (params));
+	params.unk1 = 0xFF;
+	if (0 != logitech_query (fd, LOGITECH_SEND_SHORT, G700S_QUERY_TYPE_PROFILE, (uint8_t *)&params, NULL))
+		return -1;
+	return 0;
+}
+
+int g700s_use_default_profile (int fd) {
+	struct g700s_profile_params_t params;
+	memset (&params, 0, sizeof (params));
+	if (0 != logitech_query (fd, LOGITECH_SEND_SHORT, G700S_QUERY_TYPE_PROFILE, (uint8_t *)&params, NULL))
+		return -1;
+	return 0;
+}
+
+int g700s_use_profile (int fd, uint8_t profile_page) {
+	struct g700s_profile_params_t params;
+	memset (&params, 0, sizeof (params));
+	params.unk1 = 0x01;
+	params.profile_page = profile_page;
+	if (0 != logitech_query (fd, LOGITECH_SEND_SHORT, G700S_QUERY_TYPE_PROFILE, (uint8_t *)&params, NULL))
+		return -1;
+	return 0;
+}
+
+int g700s_get_leds (int fd) {
+	struct g700s_leds_params_t params;
+	if (0 != logitech_query (fd, LOGITECH_READ_SHORT, G700S_QUERY_TYPE_LEDS, NULL, (uint8_t *)&params))
+		return -1;
+	return le16toh (params.leds);
+}
+
+int g700s_set_leds (int fd, int leds) {
+	struct g700s_leds_params_t params;
+	params.leds = htole16 (leds);
+	params.unknown = 0;
+	if (0 != logitech_query (fd, LOGITECH_SEND_SHORT, G700S_QUERY_TYPE_LEDS, (uint8_t *)&params, NULL))
+		return -1;
+	return 0;
+}
+
+uint8_t g700s_pack_resolution (int resolution) {
+	return resolution/50;
+}
+
+int g700s_unpack_resolution (uint8_t resolution) {
+	//printf("\nunpacking value %x\n",resolution);
+	return resolution*50;
+}
+
+int g700s_get_resolution (int fd, int resolution[2]) {
+	struct g700s_resolution_params_t params;
+	if (0 != logitech_query (fd, LOGITECH_READ_LONG, G700S_QUERY_TYPE_RESOLUTION, NULL, (uint8_t *)&params))
+		return  -1;
+	int i;
+	for (i = 0; i < 2; ++i)
+		resolution[i] = g700s_unpack_resolution (le16toh (params.resolution[i]));
+	return 0;
+}
+
+int g700s_set_resolution (int fd, const int resolution[2]) {
+	struct g700s_resolution_params_t params;
+	int i;
+	for (i = 0; i < 2; ++i)
+		params.resolution[i] = htole16 (g700s_pack_resolution (resolution[i]));
+	params.unknown[0] = params.unknown[1] = 0;
+	if (0 != logitech_query (fd, LOGITECH_SEND_LONG, G700S_QUERY_TYPE_RESOLUTION, (uint8_t *)&params, NULL))
+		return -1;
+	return 0;
+}
+
+uint8_t g700s_pack_refresh_rate (int refresh_rate) {
+	return 1000/refresh_rate;
+}
+
+int g700s_unpack_refresh_rate (uint8_t refresh_rate) {
+	return 1000/refresh_rate;
+}
+
+int g700s_get_refresh_rate (int fd) {
+	struct g700s_refresh_rate_params_t params;
+	if (0 != logitech_query (fd, LOGITECH_READ_SHORT, G700S_QUERY_TYPE_REFRESH_RATE, NULL, (uint8_t *)&params))
+		return -1;
+	return g700s_unpack_refresh_rate (params.refresh_rate);
+}
+
+int g700s_set_refresh_rate (int fd, int refresh_rate) {
+	struct g700s_refresh_rate_params_t params;
+	params.refresh_rate = g700s_pack_refresh_rate (refresh_rate);
+	if (0 != logitech_query (fd, LOGITECH_SEND_SHORT, G700S_QUERY_TYPE_REFRESH_RATE, (uint8_t *)&params, NULL))
+		return -1;
+	return 0;
+}
+
+int g700s_read_mem (int fd, uint8_t page, uint8_t offset, void *dest, size_t len) {
+	uint8_t buffer[16];
+	struct g700s_memory_read_params_t params;
+	int i = 0;
+	while (i < len) {
+		params.page = page;
+		params.offset = offset + i/2;
+		params.unknown = 0;
+		if (0 != logitech_query (fd, LOGITECH_READ_LONG, G700S_QUERY_TYPE_MEMORY, (uint8_t *)&params, buffer))
+			return -1;
+		memcpy (dest+i, buffer, len-i < 16 ? len-i : 16);
+		i += 16;
+	}
+	return 0;
+}
+
+int g700s_send_data (int fd, uint8_t type, uint8_t seq_num, const uint8_t *data) {
+	struct logitech_report_t report_out, report_in;
+
+	report_out.id = LOGITECH_REPORT_LONG;
+	report_out.data[0] = 0x00;
+	report_out.data[1] = type;
+	report_out.data[2] = seq_num;
+	memcpy (&report_out.data[3], data, 16);
+
+
+	if (-1 == logitech_report_out (fd, &report_out))
+		return -1;
+
+	if (type & G700S_DATA_FLAG_ACK) {
+		if (-1 == logitech_report_in (fd, &report_in))
+			return -1;
+		
+		uint8_t error_code;
+		if (logitech_is_error_report (&report_in, NULL, &error_code)) {
+#ifdef DEBUG
+			fprintf (stderr, "Received error code %d\n", error_code);
+#endif
+			return -1;
+		}
+		
+		if (report_in.data[1] != G700S_DATA_ACK) {
+#ifdef DEBUG
+			fprintf (stderr, "Wrong type of answer %d\n", report_in.data[1]);
+#endif
+			return -1;
+		}
+
+		if (report_in.data[2] != 1) {
+#ifdef DEBUG
+			fprintf (stderr, "Acknowledgment error %d\n", report_in.data[2]);
+#endif
+			return -1;
+		}
+
+		if (report_in.data[3] != seq_num) {
+#ifdef DEBUG
+			fprintf (stderr, "Wrong sequence number in acknowledgment\n");
+#endif
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+int g700s_write_some (int fd, const struct g700s_data_header_t *header, uint8_t seq_num, const void *data, size_t len) {
+	int w;
+
+	uint8_t type = G700S_DATA | G700S_DATA_FLAG_ACK;
+	uint8_t buffer[16];
+
+	int data_begin = 0;
+	if (header) {
+		size_t header_len = sizeof (struct g700s_data_header_t);
+		memcpy (&buffer[0], header, header_len);
+		data_begin = header_len;
+	}
+	else {
+		type |= G700S_DATA_FLAG_CONTINUE;
+	}
+
+	if (len < 16 - data_begin) {
+		memcpy (&buffer[data_begin], data, len);
+		memset (&buffer[data_begin + len], 0xFF, 16 - data_begin - len);
+		w = len;
+	}
+	else {
+		memcpy (&buffer[data_begin], data, 16 - data_begin);
+		w = 16 - data_begin;
+	}
+
+	if (-1 == g700s_send_data (fd, type, seq_num, buffer)) {
+		return -1;
+	}
+
+	return w;
+}
+
+int g700s_write_page (int fd, uint8_t page, uint8_t offset, const void *data, size_t len) {
+	int i;
+	int seq_num = 0;
+
+	/* Reset seq num */
+	if (0 != logitech_query (fd, LOGITECH_SEND_SHORT, G700S_QUERY_TYPE_SEQ_NUM, (uint8_t[]) { 0x01, 0, 0 }, NULL)) {
+#ifdef DEBUG
+		fprintf (stderr, "Could not reset sequence number\n");
+#endif
+		return -1;
+	}
+	
+	struct g700s_data_header_t header;
+	memset (&header, 0, sizeof (struct g700s_data_header_t));
+	header.unk1 = 1;
+	header.page = page;
+	header.offset = offset;
+	header.len = htobe16 (len);
+
+	if (-1 == (i = g700s_write_some (fd, &header, seq_num++, data, len))) {
+#ifdef DEBUG
+		fprintf (stderr, "Failed sending data\n");
+#endif
+		return -1;
+	}
+	while  (i < len) {
+		int ret;
+		if (-1 == (ret = g700s_write_some (fd, NULL, seq_num++, data+i, len-i))) {
+#ifdef DEBUG
+			fprintf (stderr, "Failed sending data\n");
+#endif
+			return -1;
+		}
+		i += ret;
+	}
+	return 0;
+}
+
+int g700s_get_button_num (uint16_t bits) {
+	int i;
+	for (i = 0; i < 16; ++i) {
+		if (bits & (1<<i)) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+size_t g700s_macro_item_len (const struct g700s_macro_item_t *item) {
+	if ((item->type & 0xF0) == 0x20)
+		return 2;
+	else if ((item->type & 0xF0) == 0x40)
+		return 3;
+	else if ((item->type & 0xF0) == 0x60)
+		return 5;
+	else
+		return 1;
+}
+const char *g700s_button_name(int number){
+    static char G_button[5];
+	if (number == 0)
+		return "Left   button";
+	if (number == 1)
+		return "Right  button";
+	if (number == 2)
+		return "Middle button";
+	if (number < 11){
+        snprintf(G_button, sizeof(G_button), "G %2d", number+1);
+		return G_button;
+    }
+	if (number == 11)
+		return "Wheel tilt left";
+	if (number == 12)
+		return "Wheel tilt right";
+	else
+		return "Wrong button nr";
+}
+
+
+
+
+
+

--- a/src/g700s.h
+++ b/src/g700s.h
@@ -1,0 +1,281 @@
+/*
+* Copyright 2015 Clément Vuchener
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+#ifndef G700S_H
+#define G700S_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* use logitech_query with one of these values and the corresponding g700s_*_params_t */
+#define G700S_QUERY_TYPE_PROFILE	0x0F // ???
+#define G700S_QUERY_TYPE_LEDS	0x51
+#define G700S_QUERY_TYPE_RESOLUTION	0x63
+#define G700S_QUERY_TYPE_REFRESH_RATE	0x64
+#define G700S_QUERY_TYPE_MEMORY_OP	0xA0
+#define G700S_QUERY_TYPE_SEQ_NUM	0xA1 // ???
+#define G700S_QUERY_TYPE_MEMORY	0xA2
+
+#define G700S_PAGE_SIZE 	512
+
+/*
+* Profile
+*/
+
+struct __attribute__ ((__packed__)) g700s_profile_params_t {
+	uint8_t unk1; // valid values are 0, 1, 2, 3 or FF
+	uint8_t profile_page;
+	uint8_t unk2; // unused?
+};
+
+int g700s_disable_profile (int fd);
+int g700s_use_default_profile (int fd);
+int g700s_use_profile (int fd, uint8_t profile_page);
+
+/*
+* LEDs
+*/
+
+#define G700S_LED_HIGH_OFF	0x0001
+#define G700S_LED_HIGH_ON	0x0002
+#define G700S_LED_MID_OFF	0x0010
+#define G700S_LED_MID_ON		0x0020
+#define G700S_LED_LOW_OFF	0x0100
+#define G700S_LED_LOW_ON		0x0200
+#define G700S_LED_LOGO_OFF	0x1000
+#define G700S_LED_LOGO_ON	0x2000
+
+struct __attribute__ ((__packed__)) g700s_leds_params_t {
+	uint16_t leds; // little endian
+	uint8_t unknown; // unused?
+};
+
+int g700s_get_leds (int fd);
+int g700s_set_leds (int fd, int leds);
+
+/*
+* Resolution
+*/
+
+struct __attribute__ ((__packed__)) g700s_resolution_params_t {
+	uint8_t resolution[2]; // little endian
+	uint8_t unknown[2]; // 80 01 even after trying to modify it
+	uint8_t padding[10]; // not used, not initialized when getting
+};
+
+/* pack/unpack resolution do not resolve endianess as it is different from memory (be) and query (le) */
+uint8_t g700s_pack_resolution (int resolution);
+int g700s_unpack_resolution (uint8_t resolution);
+
+int g700s_get_resolution (int fd, int resolution[1]);
+int g700s_set_resolution (int fd, const int resolution[2]);
+
+/*
+* Refresh rate
+*/
+
+struct __attribute__ ((__packed__)) g700s_refresh_rate_params_t {
+	uint8_t refresh_rate;
+	uint8_t unknown[2]; // unused ?
+};
+
+uint8_t g700s_pack_refresh_rate (int refresh_rate);
+int g700s_unpack_refresh_rate (uint8_t refresh_rate);
+
+int g700s_get_refresh_rate (int fd);
+int g700s_set_refresh_rate (int fd, int refresh_rate);
+
+/*
+* Memory operations
+*/
+
+#define G700S_MEM_OP_FILL	0x02
+#define G700S_MEM_OP_AND	0x03
+
+struct __attribute__ ((__packed__)) g700s_mem_op_params_t {
+	uint8_t op;
+	uint8_t unk1[1];
+	uint8_t src_offset; // used by op==4
+	uint8_t src_len; // used by op==4
+	uint8_t unk2[2];
+	uint8_t page;
+	uint8_t offset;
+	uint8_t unk3[2];
+	uint16_t len; // big endian
+	uint8_t unk4[4];
+};
+
+/*
+* Memory read
+*/
+
+struct __attribute__ ((__packed__)) g700s_memory_read_params_t {
+	uint8_t page;
+	uint8_t offset;
+	uint8_t unknown; // unused?
+};
+
+int g700s_read_mem (int fd, uint8_t page, uint8_t offset, void *dest, size_t len);
+
+/*
+* Memory write
+*/
+
+#define G700S_DATA	0x90
+#define G700S_DATA_FLAG_CONTINUE	0x01
+#define G700S_DATA_FLAG_ACK	0x02
+
+#define G700S_DATA_ACK	0x50
+
+struct __attribute__ ((__packed__)) g700s_data_header_t {
+	uint8_t unk1; // must be 0x01
+	uint8_t page;
+	uint8_t offset;
+	uint8_t unk2[2];
+	uint16_t len; // big endian
+	uint8_t unk3[2];
+};
+
+/**
+* Low-level send data with type \p type.
+*
+* data may need to contain a header.
+*/
+int g700s_send_data (int fd, uint8_t type, uint8_t seq_num, const uint8_t *data);
+/**
+* Send has much data as it can with only one message.
+*
+* Returns the number of bytes sent.
+*/
+int g700s_write_some (int fd, const struct g700s_data_header_t *header, uint8_t seq_num, const void *data, size_t len);
+/**
+* Send len bytes in data.
+*
+* Reset the sequence number and send several messages.
+*/
+int g700s_write_page (int fd, uint8_t page, uint8_t offset, const void *data, size_t len);
+
+/*
+* Profile
+*/
+
+#define G700S_BINDING_MACRO_MAX 0x7F // Actually max page number is 0x12, but bit 7 seems to be the difference between macro and the rest
+#define G700S_BINDING_MOUSE_BUTTON	0x81
+#define G700S_BINDING_KEY	0x82
+#define G700S_BINDING_SPECIAL_BUTTON	0x83
+#define G700S_BINDING_CONSUMER_CONTROL	0x84
+#define G700S_BINDING_UNSET	0x8F
+
+struct __attribute__ ((__packed__)) g700s_profile_t {
+	struct __attribute__ ((__packed__)) {
+		uint8_t resolution[2]; // big endian
+		uint16_t leds; // little endian
+	} dpi_mode[5];
+	uint8_t default_mode;
+	uint8_t angle;
+	uint8_t angle_snap;
+	uint8_t acceleration;
+	uint8_t refresh_rate;
+	uint8_t unk[10];
+
+
+
+	struct __attribute__ ((__packed__)) {
+		uint8_t type;
+		union {
+			uint8_t bytes[2];
+			uint16_t button; // little endian
+			struct __attribute__ ((__packed__)) {
+				uint8_t modifier;
+				uint8_t usage;
+			} key;
+			uint16_t cc_usage; // big endian
+			struct __attribute__ ((__packed__)) {
+				uint8_t offset;
+				uint8_t unused;
+			} macro;
+		} value;
+	} binding[13];
+};
+
+#define G700S_SPECIAL_BUTTON_PAN_LEFT	0x0001
+#define G700S_SPECIAL_BUTTON_PAN_RIGHT	0x0002
+#define G700S_SPECIAL_BUTTON_BATTERY 	0x0003
+#define G700S_SPECIAL_BUTTON_DPI_PLUS	0x0004
+#define G700S_SPECIAL_BUTTON_DPI_MINUS	0x0008
+#define G700S_SPECIAL_BUTTON_DPI_CYC_DOWN    0x0009
+#define G700S_SPECIAL_BUTTON_PROFILE_CYC	0x0011
+#define G700S_SPECIAL_BUTTON_DPI_CYC_UP    0x0105
+
+/* Returns the button number from the bitfield. */
+int g700s_get_button_num (uint16_t bits);
+
+/* Prints user friendly mouse button identifier */
+const char *g700s_button_name(int number);
+
+/*
+* Macro
+*/
+
+#define G700S_MACRO_NOOP	0x00
+#define G700S_MACRO_WAIT_RELEASE	0x01
+#define G700S_MACRO_REPEAT_IF_PRESSED 0x02
+#define G700S_MACRO_REPEAT	0x03
+#define G700S_MACRO_KEY_PRESS	0x20
+#define G700S_MACRO_KEY_RELEASE	0x21
+#define G700S_MACRO_MODIFIER_PRESS	0x22
+#define G700S_MACRO_MODIFIER_RELEASE	0x23
+#define G700S_MACRO_WHEEL	0x24
+#define G700S_MACRO_BUTTON_PRESS	0x40
+#define G700S_MACRO_BUTTON_RELEASE	0x41
+#define G700S_MACRO_CONSUMER_CONTROL	0x42
+#define G700S_MACRO_DELAY	0x43
+#define G700S_MACRO_JUMP	0x44
+#define G700S_MACRO_JUMP_IF_PRESSED	0x45
+#define G700S_MACRO_MOUSE_AXES	0x60
+#define G700S_MACRO_WAIT_HOLD	0x61
+#define G700S_MACRO_END	0xFF
+
+struct __attribute__ ((__packed__)) g700s_macro_item_t {
+	uint8_t type;
+	union {
+		uint8_t key_usage;
+		uint8_t modifier_bits;
+		int8_t wheel;
+		uint16_t button;
+		uint16_t cc_usage;
+		uint16_t delay;
+		struct __attribute__ ((__packed__)) {
+			uint8_t page;
+			uint8_t offset;
+		} jump;
+		struct __attribute__ ((__packed__)) {
+			uint16_t axis[2];
+		} mouse;
+		struct __attribute__ ((__packed__)) {
+			uint16_t delay;
+			uint8_t page;
+			uint8_t offset;
+		} hold;
+	} value;
+};
+
+/* Get the real size for the macro item */
+size_t g700s_macro_item_len (const struct g700s_macro_item_t *item);
+
+#endif /* !defined G700S_H */


### PR DESCRIPTION
I edited copies of g500.c g500.h and g500-parse-profile.c so as to support g700s profiles.
I also added hid code to user friendly translation for modifier keys and alphabetic keys to g500-parse-macro.c.
Finally I added some minor changes to docs based on my experiments.
I can help with researching g700s model.